### PR TITLE
feat!: new algorithm

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Deterministically map service names to port numbers `(1024,65535)`.
 
 ```bash
 $ npx named-port Filecoin Station Core
-7834
+51806
 ```
 
 ```js
@@ -24,5 +24,9 @@ console.log(namedPort('Filecoin Station Core', { min: 3000, max: 10000 }))
 ## Algorithm
 
 ```
-port = min + H(name) % (max - min)
+port = min + H(name) % (max - min + 1)
 ```
+
+- `H(name)`: `hash = 0; for each char c: hash = (hash * 31 + c.charCodeAt(0)) >>> 0`
+- `31`: prime multiplier for even distribution
+- `>>> 0`: 32-bit unsigned overflow handling

--- a/index.js
+++ b/index.js
@@ -1,13 +1,13 @@
-import crypto from 'node:crypto'
 import { MAX, MIN } from './constants.js'
 
 const namedPort = (str, options) => {
   const { min = MIN, max = MAX } = options ?? {}
   if (min >= max) throw new Error('min option must be less than max option')
-  // TODO: sha512 isn't big enough to cover the full port range
-  const hash = crypto.createHash('sha512').update(str).digest()
-  const n = hash.reduce((a, b) => a + b, 0)
-  return min + n % (max - min)
+  let hash = 0
+  for (const char of str) {
+    hash = (hash * 31 + char.charCodeAt(0)) >>> 0
+  }
+  return min + hash % (max - min + 1)
 }
 
 export default namedPort

--- a/test.js
+++ b/test.js
@@ -4,7 +4,7 @@ import namedPort from './index.js'
 import { MAX, MIN } from './constants.js'
 
 test('named port', () => {
-  assert.strictEqual(namedPort('Filecoin Station Core'), 7834)
+  assert.strictEqual(namedPort('Filecoin Station Core'), 51806)
 })
 
 test('port is within default range', () => {
@@ -19,6 +19,15 @@ test('port is within custom range', () => {
   const port = namedPort('project', { min, max })
   assert.ok(port >= min)
   assert.ok(port <= max)
+})
+
+test('range is inclusive', () => {
+  const min = 10
+  const max = 12
+  const results = new Set(['a', 'b', 'c', 'd', 'e', 'f'].map(str => namedPort(str, { min, max })))
+  assert.strictEqual(results.size, max - min + 1)
+  assert.ok(results.has(min))
+  assert.ok(results.has(max))
 })
 
 test('throw error when min >= max', () => {


### PR DESCRIPTION
BREAKING: default port values have changed (Filecoin Station Core now maps to 51806)

The previous implementation used `sha512` and then summed all digest bytes, reducing the effective hash space to 0–16320 (~16bit). This change replaces it with a 32-bit rolling hash (`hash = hash * 31 + charCode`), which:
- increases the hash space from ~16k to ~4.2B values
- removes the crypto dependency