### PR TITLE
fix: add entry point export

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,12 @@
   "repository": "juliangruber/named-port",
   "description": "Deterministically map service names to port numbers",
   "type": "module",
-  "types": "index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./index.d.ts",
+      "default": "./index.js"
+    }
+  },
   "engines": {
     "node": ">=20"
   },


### PR DESCRIPTION
```
(node:18448) [DEP0151] DeprecationWarning: No "main" or "exports" field defined in the package.json for \node_modules\named-port\.
Default "index" lookups for the main are deprecated for ES modules.
```

Fixed package entry resolution to avoid [DEP0151](https://nodejs.org/api/deprecations.html#dep0151-main-index-lookup-and-extension-searching) warnings by using [exports](https://nodejs.org/api/packages.html#main-entry-point-export).

